### PR TITLE
Add Datadog attribute to set unique hostname for reporting

### DIFF
--- a/onsite_revenue_management/recipes/configure.rb
+++ b/onsite_revenue_management/recipes/configure.rb
@@ -3,6 +3,7 @@ node[:deploy].each do |application, deploy|
 
   node.set[:datadog][:tags][:env] = deploy['rails_env']
   node.set[:datadog][:api_key] = deploy[:environment_variables]['DATADOG_KEY']
+  node.set[:datadog][:hostname] = "rev.#{deploy['rails_env']}.#{node["opsworks"]["instance"]["hostname"]}"
   include_recipe 'datadog::dd-agent'
 
 


### PR DESCRIPTION
Datadog gets confused when identical hostnames are reported for different instances. This change is to provide unique hostname for each instance.